### PR TITLE
Store custom data also on exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Persist job execution information on a support model `ActiveJobStore::Record`.
 It can be useful to:
 - improve jobs logging capabilities;
 - query historical data about job executions;
-- track a job's state or progress;
-- extract job's statistical data.
+- extract job's statistical data;
+- track a job's state or add custom data to the jobs.
 
 Support some customizations:
 - set custom data attributes (via `active_job_store_custom_data` accessor);
-- format the job result to store (overriding `active_job_store_format_result`).
+- format the job result to store (overriding `active_job_store_format_result` method).
 
 ## Installation
 

--- a/lib/active_job_store.rb
+++ b/lib/active_job_store.rb
@@ -28,10 +28,15 @@ module ActiveJobStore
         end
         store_record.update!(details: job.as_json.except(*IGNORE_ATTRS), state: :started, started_at: Time.current)
         result = block.call
-        result_data = job.active_job_store_format_result(result)
-        store_record.update!(state: :completed, completed_at: Time.current, result: result_data, custom_data: active_job_store_custom_data)
+        formatted_result = job.active_job_store_format_result(result)
+        store_record.update!(
+          state: :completed,
+          completed_at: Time.current,
+          result: formatted_result,
+          custom_data: active_job_store_custom_data
+        )
       rescue StandardError => e
-        store_record.update!(state: :error, exception: e.inspect)
+        store_record.update!(state: :error, exception: e.inspect, custom_data: active_job_store_custom_data)
         raise
       end
     end

--- a/spec/integration/active_job_store/active_job_store_spec.rb
+++ b/spec/integration/active_job_store/active_job_store_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe ActiveJobStore do
         job_class: 'TestJob',
         state: 'error',
         arguments: [111],
-        custom_data: nil,
+        custom_data: ['step-1'],
         exception: '#<RuntimeError: Some exception>'
       }
       expect(ActiveJobStore::Record.last).to have_attributes(expected_attributes)


### PR DESCRIPTION
In this PR:
- feat: store custom data also on exceptions.
