### PR TITLE
Move the internal logic in a new Store class

### DIFF
--- a/lib/active_job_store.rb
+++ b/lib/active_job_store.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 require_relative 'active_job_store/engine'
+require_relative 'active_job_store/store'
 
 module ActiveJobStore
-  IGNORE_ATTRS = %w[arguments job_id successfully_enqueued].freeze
-
   attr_accessor :active_job_store_custom_data
 
   class << self
@@ -12,31 +11,20 @@ module ActiveJobStore
       base.extend(ClassMethods)
 
       base.around_enqueue do |job, block|
-        store_record = ::ActiveJobStore::Record.find_or_create_by!(job.active_job_store_reference) do |record|
-          record.arguments = job.arguments
-          record.details = job.as_json.except(*IGNORE_ATTRS)
-          record.state = :initialized
+        store.prepare_record_on_enqueue(job)
+        store.job_enqueued! do
+          block.call
         end
-        store_record.lock! # NOTE: needed to avoid update conflicts with perform when setting the state to enqueued
-        block.call
-        store_record.update!(state: :enqueued, enqueued_at: Time.current)
       end
 
       base.around_perform do |job, block|
-        store_record = ::ActiveJobStore::Record.find_or_initialize_by(job.active_job_store_reference) do |record|
-          record.arguments = job.arguments
-        end
-        store_record.update!(details: job.as_json.except(*IGNORE_ATTRS), state: :started, started_at: Time.current)
+        store.prepare_record_on_perform(job)
+        store.job_started!
         result = block.call
         formatted_result = job.active_job_store_format_result(result)
-        store_record.update!(
-          state: :completed,
-          completed_at: Time.current,
-          result: formatted_result,
-          custom_data: active_job_store_custom_data
-        )
+        store.job_competed!(custom_data: active_job_store_custom_data, result: formatted_result)
       rescue StandardError => e
-        store_record.update!(state: :error, exception: e.inspect, custom_data: active_job_store_custom_data)
+        store.job_failed!(exception: e, custom_data: active_job_store_custom_data)
         raise
       end
     end
@@ -46,13 +34,15 @@ module ActiveJobStore
     result
   end
 
-  def active_job_store_reference
-    { job_id: job_id, job_class: self.class.to_s }
-  end
-
   module ClassMethods
     def job_executions
       ::ActiveJobStore::Record.where(job_class: to_s)
     end
+  end
+
+  private
+
+  def store
+    @store ||= ::ActiveJobStore::Store.new
   end
 end

--- a/lib/active_job_store/store.rb
+++ b/lib/active_job_store/store.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ActiveJobStore
+  class Store
+    IGNORE_ATTRS = %w[arguments store job_id successfully_enqueued].freeze
+
+    attr_reader :record
+
+    def job_competed!(result:, custom_data:)
+      record.update!(state: :completed, completed_at: Time.current, result: result, custom_data: custom_data)
+      record
+    end
+
+    def job_enqueued!
+      record.lock! # NOTE: needed to avoid update conflicts with perform when setting the state to enqueued
+      yield
+      record.update!(state: :enqueued, enqueued_at: Time.current)
+      record
+    end
+
+    def job_failed!(exception:, custom_data:)
+      record.update!(state: :error, exception: exception.inspect, custom_data: custom_data)
+      record
+    end
+
+    def job_started!
+      record.update!(state: :started, started_at: Time.current)
+      record
+    end
+
+    def prepare_record_on_enqueue(job)
+      @record = ::ActiveJobStore::Record.find_or_create_by!(record_reference(job)) do |record|
+        record.arguments = job.arguments
+        record.details = job.as_json.except(*IGNORE_ATTRS)
+        record.state = :initialized
+      end
+    end
+
+    def prepare_record_on_perform(job)
+      @record = ::ActiveJobStore::Record.find_or_initialize_by(record_reference(job)) do |record|
+        record.arguments = job.arguments
+      end
+      record.details = job.as_json.except(*IGNORE_ATTRS)
+      record
+    end
+
+    private
+
+    def record_reference(job)
+      {
+        job_id: job.job_id,
+        job_class: job.class.to_s
+      }
+    end
+  end
+end

--- a/spec/integration/active_job_store_spec.rb
+++ b/spec/integration/active_job_store_spec.rb
@@ -27,11 +27,16 @@ RSpec.describe ActiveJobStore do
     it 'creates an ActiveJobStore::Record with state completed', :aggregate_failures do
       expect { perform_now }.to output("123\n").to_stdout.and change(ActiveJobStore::Record, :count).by(1)
 
+      expected_details = a_hash_including(
+        'executions' => 1,
+        'queue_name' => 'default'
+      )
       expected_attributes = {
         job_class: 'TestJob',
         state: 'completed',
         arguments: [123],
         custom_data: nil,
+        details: expected_details,
         result: 'some result',
         started_at: Time.current,
         completed_at: Time.current

--- a/spec/unit/active_job_store/store_spec.rb
+++ b/spec/unit/active_job_store/store_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActiveJobStore::Store do
+  describe '#job_competed!' do
+    subject(:job_competed!) { store.job_competed!(result: result, custom_data: custom_data) }
+
+    let(:custom_data) { { key1: 'value1', key2: 'value2' } }
+    let(:result) { 'some result' }
+    let(:store) { described_class.new }
+    let(:record) { instance_double(ActiveJobStore::Record, update!: nil) }
+
+    before { allow(store).to receive(:record).and_return(record) }
+
+    it 'updates the store record with completed state', :freeze_time do
+      job_competed!
+      expected_attributes = {
+        state: :completed,
+        completed_at: Time.current,
+        result: 'some result',
+        custom_data: { key1: 'value1', key2: 'value2' }
+      }
+      expect(record).to have_received(:update!).with(expected_attributes)
+    end
+  end
+
+  describe '#job_enqueued!' do
+    subject(:job_enqueued!) { store.job_enqueued! { 'enqueuing...' } }
+
+    let(:store) { described_class.new }
+    let(:record) { instance_double(ActiveJobStore::Record, lock!: nil, update!: nil) }
+
+    before { allow(store).to receive(:record).and_return(record) }
+
+    it 'updates the store record with enqueued state', :freeze_time do
+      job_enqueued!
+      expect(record).to have_received(:update!).with(state: :enqueued, enqueued_at: Time.current)
+    end
+  end
+
+  describe '#job_failed!' do
+    subject(:job_failed!) { store.job_failed!(exception: exception, custom_data: custom_data) }
+
+    let(:custom_data) { { key1: 'value1', key2: 'value2' } }
+    let(:exception) { instance_double(StandardError, inspect: 'some error') }
+    let(:store) { described_class.new }
+    let(:record) { instance_double(ActiveJobStore::Record, update!: nil) }
+
+    before { allow(store).to receive(:record).and_return(record) }
+
+    it 'updates the store record with error state', :freeze_time do
+      job_failed!
+      expected_attributes = { state: :error, exception: 'some error', custom_data: { key1: 'value1', key2: 'value2' } }
+      expect(record).to have_received(:update!).with(expected_attributes)
+    end
+  end
+
+  describe '#job_started!' do
+    subject(:job_started!) { store.job_started! }
+
+    let(:store) { described_class.new }
+    let(:record) { instance_double(ActiveJobStore::Record, update!: nil) }
+
+    before { allow(store).to receive(:record).and_return(record) }
+
+    it 'updates the store record with started state', :freeze_time do
+      job_started!
+      expect(record).to have_received(:update!).with(state: :started, started_at: Time.current)
+    end
+  end
+
+  describe '#prepare_record_on_enqueue' do
+    subject(:prepare_record_on_enqueue) { described_class.new.prepare_record_on_enqueue(job) }
+
+    let(:job) { double('SomeJob', job_id: 'some-id', arguments: [123]) } # rubocop:disable RSpec/VerifiedDoubles
+
+    before { allow(ActiveJobStore::Record).to receive(:find_or_create_by!) }
+
+    it 'prepares the record to store the job state' do
+      prepare_record_on_enqueue
+      expected_attributes = { job_class: a_kind_of(String), job_id: 'some-id' }
+      expect(ActiveJobStore::Record).to have_received(:find_or_create_by!).with(expected_attributes)
+    end
+  end
+
+  describe '#prepare_record_on_perform' do
+    subject(:prepare_record_on_perform) { described_class.new.prepare_record_on_perform(job) }
+
+    let(:job) { double('SomeJob', job_id: 'some-id', arguments: [123]) } # rubocop:disable RSpec/VerifiedDoubles
+    let(:record) { instance_double(ActiveJobStore::Record, 'details=' => nil) }
+
+    before { allow(ActiveJobStore::Record).to receive(:find_or_initialize_by).and_return(record) }
+
+    it 'prepares the record to store the job state' do
+      prepare_record_on_perform
+      expected_attributes = { job_class: a_kind_of(String), job_id: 'some-id' }
+      expect(ActiveJobStore::Record).to have_received(:find_or_initialize_by).with(expected_attributes)
+    end
+  end
+end

--- a/spec/unit/active_job_store_spec.rb
+++ b/spec/unit/active_job_store_spec.rb
@@ -28,17 +28,6 @@ RSpec.describe ActiveJobStore do
     end
   end
 
-  describe '#active_job_store_reference' do
-    subject(:active_job_store_reference) { TestJob.new.active_job_store_reference }
-
-    it 'returns the job reference attributes' do
-      expect(active_job_store_reference).to match(
-        job_class: 'TestJob',
-        job_id: a_kind_of(String)
-      )
-    end
-  end
-
   describe '#active_job_store_format_result' do
     subject(:active_job_store_format_result) { TestJob.new.active_job_store_format_result(123) }
 


### PR DESCRIPTION
Refactor the `ActiveJobStore` main module to use a new `Store` entity as interface to the internal API.