### PR TITLE
Permit to save the custom data while performing a job

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It can be useful to:
 - improve jobs logging capabilities;
 - query historical data about job executions;
 - extract job's statistical data;
-- track a job's state or add custom data to the jobs.
+- track a job's state / set progress value / add custom data to the jobs.
 
 Support some customizations:
 - set custom data attributes (via `active_job_store_custom_data` accessor);
@@ -79,7 +79,28 @@ SomeJob.job_executions.completed.map { |job| { id: job.id, execution_time: job.c
 
 ## Customizations
 
-If you need to store custom data, use `active_job_store_custom_data` accessor:
+To store the custom data (ex. a progress value):
+
+```rb
+class AnotherJob < ApplicationJob
+  include ActiveJobStore
+
+  def perform
+    # do something...
+    save_job_custom_data(progress: 0.5)
+    # do something else...
+    save_job_custom_data(progress: 1.0)
+
+    'some_result'
+  end
+end
+
+# Usage example:
+AnotherJob.perform_later(456)
+AnotherJob.job_executions.last.custom_data['progress'] # 1.0 (at the end)
+```
+
+If you need to manipulate the custom data, there is the `active_job_store_custom_data` accessor:
 
 ```rb
 class AnotherJob < ApplicationJob
@@ -96,6 +117,7 @@ class AnotherJob < ApplicationJob
   end
 end
 
+# Usage example:
 AnotherJob.perform_now(123)
 AnotherJob.job_executions.last.custom_data
 # => [{"time"=>"2022-11-09T21:20:57.580Z", "message"=>"SomeJob step 1"}, {"time"=>"2022-11-09T21:20:58.581Z", "message"=>"SomeJob step 2"}]
@@ -116,6 +138,7 @@ class AnotherJob < ApplicationJob
   end
 end
 
+# Usage example:
 AnotherJob.perform_now(123)
 AnotherJob.job_executions.last.result
 # => 84

--- a/lib/active_job_store.rb
+++ b/lib/active_job_store.rb
@@ -34,6 +34,11 @@ module ActiveJobStore
     result
   end
 
+  def save_job_custom_data(custom_data = nil)
+    self.active_job_store_custom_data = custom_data if custom_data
+    store.update_job_custom_data(active_job_store_custom_data)
+  end
+
   module ClassMethods
     def job_executions
       ::ActiveJobStore::Record.where(job_class: to_s)

--- a/lib/active_job_store/store.rb
+++ b/lib/active_job_store/store.rb
@@ -44,6 +44,10 @@ module ActiveJobStore
       record
     end
 
+    def update_job_custom_data(custom_data)
+      record.update!(custom_data: custom_data)
+    end
+
     private
 
     def record_reference(job)

--- a/lib/active_job_store/store.rb
+++ b/lib/active_job_store/store.rb
@@ -2,7 +2,7 @@
 
 module ActiveJobStore
   class Store
-    IGNORE_ATTRS = %w[arguments store job_id successfully_enqueued].freeze
+    DETAILS_ATTRS = %w[exception_executions executions priority queue_name scheduled_at timezone].freeze
 
     attr_reader :record
 
@@ -31,7 +31,7 @@ module ActiveJobStore
     def prepare_record_on_enqueue(job)
       @record = ::ActiveJobStore::Record.find_or_create_by!(record_reference(job)) do |record|
         record.arguments = job.arguments
-        record.details = job.as_json.except(*IGNORE_ATTRS)
+        record.details = DETAILS_ATTRS.zip(DETAILS_ATTRS.map { job.send(_1) }).to_h
         record.state = :initialized
       end
     end
@@ -40,7 +40,7 @@ module ActiveJobStore
       @record = ::ActiveJobStore::Record.find_or_initialize_by(record_reference(job)) do |record|
         record.arguments = job.arguments
       end
-      record.details = job.as_json.except(*IGNORE_ATTRS)
+      record.details = DETAILS_ATTRS.zip(DETAILS_ATTRS.map { job.send(_1) }).to_h
       record
     end
 

--- a/spec/dummy70/app/jobs/another_job.rb
+++ b/spec/dummy70/app/jobs/another_job.rb
@@ -4,7 +4,13 @@ class AnotherJob < ApplicationJob
   include ActiveJobStore
 
   def perform(some_id)
-    Rails.logger.debug { "> AnotherJob is performing with #{some_id}" }
+    save_job_custom_data(progress: 0.0)
+    Rails.logger.debug { "> AnotherJob is performing with #{some_id} - Step 1" }
+    sleep 2
+    save_job_custom_data(progress: 0.5)
+    Rails.logger.debug { "> AnotherJob is performing with #{some_id} - Step 2" }
+    sleep 2
+    save_job_custom_data(progress: 1.0)
 
     42
   end

--- a/spec/dummy70/app/jobs/some_job.rb
+++ b/spec/dummy70/app/jobs/some_job.rb
@@ -7,9 +7,12 @@ class SomeJob < ApplicationJob
     self.active_job_store_custom_data = []
 
     active_job_store_custom_data << { time: Time.current, message: 'SomeJob step 1' }
+    save_job_custom_data
+
     Rails.logger.debug { "> SomeJob is performing with #{some_id}" }
-    sleep 1
+    sleep 3
     active_job_store_custom_data << { time: Time.current, message: 'SomeJob step 2' }
+    save_job_custom_data
 
     'some_result'
   end

--- a/spec/integration/active_job_store_spec.rb
+++ b/spec/integration/active_job_store_spec.rb
@@ -238,4 +238,67 @@ RSpec.describe ActiveJobStore do
       expect(ActiveJobStore::Record.last).to have_attributes(expected_attributes)
     end
   end
+
+  context 'when updating custom data during the perform' do
+    let(:perform_now) { TestJob.perform_now(111) }
+    let(:test_job_class) do
+      Class.new(ApplicationJob) do
+        include ActiveJobStore
+
+        def perform(test_arg) # rubocop:disable Lint/UnusedMethodArgument
+          save_job_custom_data(progress: 0.5)
+          # do something else ...
+          save_job_custom_data(progress: 1.0)
+
+          'some result'
+        end
+      end
+    end
+
+    it 'executes only the expected queries', :aggregate_failures, :freeze_time do
+      queries = []
+      enable_queries_tracking { |query| queries << query }
+      perform_now
+
+      expected_queries = [
+        'SELECT "active_job_store".* FROM "active_job_store" WHERE "active_job_store"."job_id" = ? AND "active_job_store"."job_class" = ? LIMIT ?',
+        'INSERT INTO "active_job_store" ("job_id", "job_class", "state", "arguments", "custom_data", "details", "result", "exception", "enqueued_at", "started_at", "completed_at", "created_at") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        'UPDATE "active_job_store" SET "custom_data" = ? WHERE "active_job_store"."id" = ?',
+        'UPDATE "active_job_store" SET "custom_data" = ? WHERE "active_job_store"."id" = ?',
+        'UPDATE "active_job_store" SET "state" = ?, "result" = ?, "completed_at" = ? WHERE "active_job_store"."id" = ?'
+      ]
+      expect(queries.pluck(:sql)).to match_array(expected_queries)
+
+      details = { 'exception_executions' => {}, 'executions' => 1, 'priority' => nil, 'queue_name' => 'default', 'timezone' => 'UTC' }
+      expected_insert_values = [a_kind_of(String), 'TestJob', 'started', [111], nil, details, nil, nil, nil, Time.current, nil, Time.current]
+      expect(queries[1]).to include(values: expected_insert_values)
+      expect(queries[2]).to include(values: [{ 'progress' => 0.5 }, 1])
+      expect(queries[3]).to include(values: [{ 'progress' => 1.0 }, 1])
+      expect(queries[4]).to include(values: ['completed', 'some result', Time.current, 1])
+    end
+
+    context 'with a stubbed record' do
+      let(:record) { instance_double(ActiveJobStore::Record, 'details=': nil, update!: nil) }
+
+      before do
+        allow(ActiveJobStore::Record).to receive(:find_or_initialize_by).and_return(record)
+      end
+
+      it 'stores custom data in the ActiveJobStore Record', :aggregate_failures, :freeze_time do
+        perform_now
+
+        expect(record).to have_received(:update!).with(started_at: Time.current, state: :started).ordered
+        expect(record).to have_received(:update!).with(custom_data: { progress: 0.5 }).ordered
+        expect(record).to have_received(:update!).with(custom_data: { progress: 1.0 }).ordered
+
+        expected_attributes = {
+          completed_at: Time.current,
+          custom_data: { progress: 1.0 },
+          result: 'some result',
+          state: :completed
+        }
+        expect(record).to have_received(:update!).with(expected_attributes).ordered
+      end
+    end
+  end
 end

--- a/spec/integration/active_job_store_spec.rb
+++ b/spec/integration/active_job_store_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ActiveJobStore do
       ]
       expect(queries.pluck(:sql)).to match_array(expected_queries)
 
-      details = { 'exception_executions' => {}, 'executions' => 1, 'priority' => nil, 'queue_name' => 'default', 'timezone' => 'UTC' }
+      details = { 'exception_executions' => {}, 'executions' => 1, 'priority' => nil, 'queue_name' => 'default', 'scheduled_at' => nil, 'timezone' => 'UTC' }
       expected_insert_values = [a_kind_of(String), 'TestJob', 'started', [123], nil, details, nil, nil, nil, Time.current, nil, Time.current]
       expect(queries[1]).to include(values: expected_insert_values)
 
@@ -93,7 +93,7 @@ RSpec.describe ActiveJobStore do
       ]
       expect(queries.pluck(:sql).map(&:strip)).to match_array(expected_queries)
 
-      details = { 'exception_executions' => {}, 'executions' => 0, 'priority' => nil, 'queue_name' => {}, 'timezone' => 'UTC' }
+      details = { 'exception_executions' => {}, 'executions' => 0, 'priority' => nil, 'queue_name' => 'default', 'scheduled_at' => nil, 'timezone' => 'UTC' }
       expected_insert_values = [a_kind_of(String), 'TestJob', 'initialized', ['some arg'], nil, details, nil, nil, nil, nil, nil, Time.current]
       expect(queries[1]).to include(values: expected_insert_values)
 
@@ -130,7 +130,7 @@ RSpec.describe ActiveJobStore do
       ]
       expect(queries.pluck(:sql).map(&:strip)).to match_array(expected_queries)
 
-      details = { 'exception_executions' => {}, 'executions' => 0, 'priority' => nil, 'queue_name' => {}, 'scheduled_at' => a_kind_of(Float), 'timezone' => 'UTC' }
+      details = { 'exception_executions' => {}, 'executions' => 0, 'priority' => nil, 'queue_name' => 'default', 'scheduled_at' => a_kind_of(Float), 'timezone' => 'UTC' }
       expected_insert_values = [a_kind_of(String), 'TestJob', 'initialized', [true], nil, details, nil, nil, nil, nil, nil, Time.current]
       expect(queries[1]).to include(values: expected_insert_values)
 
@@ -269,7 +269,7 @@ RSpec.describe ActiveJobStore do
       ]
       expect(queries.pluck(:sql)).to match_array(expected_queries)
 
-      details = { 'exception_executions' => {}, 'executions' => 1, 'priority' => nil, 'queue_name' => 'default', 'timezone' => 'UTC' }
+      details = { 'exception_executions' => {}, 'executions' => 1, 'priority' => nil, 'queue_name' => 'default', 'scheduled_at' => nil, 'timezone' => 'UTC' }
       expected_insert_values = [a_kind_of(String), 'TestJob', 'started', [111], nil, details, nil, nil, nil, Time.current, nil, Time.current]
       expect(queries[1]).to include(values: expected_insert_values)
       expect(queries[2]).to include(values: [{ 'progress' => 0.5 }, 1])

--- a/spec/unit/active_job_store/store_spec.rb
+++ b/spec/unit/active_job_store/store_spec.rb
@@ -87,7 +87,9 @@ RSpec.describe ActiveJobStore::Store do
   describe '#prepare_record_on_perform' do
     subject(:prepare_record_on_perform) { described_class.new.prepare_record_on_perform(job) }
 
-    let(:job) { double('SomeJob', job_id: 'some-id', arguments: [123]) } # rubocop:disable RSpec/VerifiedDoubles
+    let(:job) do
+      double('SomeJob', job_id: 'some-id', arguments: [123], exception_executions: nil, executions: nil, priority: nil, queue_name: nil, scheduled_at: nil, timezone: nil) # rubocop:disable RSpec/VerifiedDoubles
+    end
     let(:record) { instance_double(ActiveJobStore::Record, 'details=' => nil) }
 
     before { allow(ActiveJobStore::Record).to receive(:find_or_initialize_by).and_return(record) }


### PR DESCRIPTION
Add a new method `save_custom_data` to store the custom data on the support record during the job's perform.